### PR TITLE
fix dot formatting center statename left justify actions

### DIFF
--- a/src/mechanus_dsl.erl
+++ b/src/mechanus_dsl.erl
@@ -66,7 +66,10 @@ visualize(MrlFile) ->
   ok.
 
 get_vertices(Parsed) ->
-  [{?a2l(State), lists:flatten(io_lib:format("~p: ~p", [State, Ens ++ Exs]))} ||
+  [{?a2l(State), lists:flatten(
+            [ io_lib:format("~s\\n", [State])
+            , lists:map(fun (Item) -> io_lib:format("~p\\l", [Item]) end, Ens ++ Exs)
+            ])} ||
      [State, Ens, Exs|_] <- [?t2l(X) || X <- Parsed]].
 
 get_edges(Parsed) ->


### PR DESCRIPTION
Together with PR on kivra/stdlib2 I can get out a dot label such as label="foo\nbar\lbaz\r" and get it rendered as centered, left justified and right justified. The mrl state names are centered and the actions are left justified to get this result:

![new_payable_content dot](https://user-images.githubusercontent.com/52162652/67389430-ea871200-f59a-11e9-82f6-054fa51ebd72.png)
