### PR TITLE
Add context for no_such_transition errors 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Tridrone](http://upload.wikimedia.org/wikipedia/en/5/56/Tridrone.JPG)
+![Tridrone](https://upload.wikimedia.org/wikipedia/en/5/56/Tridrone.JPG)
 
 Mechanus (v0.1.0)
 ========

--- a/src/mechanus_modron.erl
+++ b/src/mechanus_modron.erl
@@ -256,13 +256,13 @@ exit_state(#state{name=Name, tab=Tab, on_entry=OnEntry, on_exit=OnExit}, Event, 
       {State, OnExit};
     {error, notfound} ->
       ?error("~p: ~p no transition for ~p", [ID, Name, Event]),
-      throw({error, {no_such_transition, [
-        {modron_id, ID},
-        {modron_state, Name},
-        {modron_entry_actions, OnEntry},
-        {modron_exit_actions, OnExit},
-        {modron_transition_to, Event}
-      ]}})
+      throw({error, {no_such_transition,
+            [ {modron_id, ID}
+            , {modron_state, Name}
+            , {modron_entry_actions, OnEntry}
+            , {modron_exit_actions, OnExit}
+            , {modron_transition_to, Event}
+            ] }})
   end.
 
 enter_state(#state{on_entry=OnEntry}) -> OnEntry.

--- a/src/mechanus_modron.erl
+++ b/src/mechanus_modron.erl
@@ -248,7 +248,7 @@ is_valid(#event{valid_from=TS}) -> mechanus:now() > TS.
 -spec exit_state(#state{}, atom(), mechanus:id()) ->
                     {#state{}, [module()]} | no_return().
 %% @doc Go to the next state via Event.
-exit_state(#state{name=Name, tab=Tab, on_exit=OnExit}, Event, ID) ->
+exit_state(#state{name=Name, tab=Tab, on_entry=OnEntry, on_exit=OnExit}, Event, ID) ->
   case eon:get(Tab, Event) of
     {ok, State} ->
       ?info("~p: ~p transitioning to ~p via ~p",
@@ -256,7 +256,13 @@ exit_state(#state{name=Name, tab=Tab, on_exit=OnExit}, Event, ID) ->
       {State, OnExit};
     {error, notfound} ->
       ?error("~p: ~p no transition for ~p", [ID, Name, Event]),
-      throw({error, no_such_transition})
+      throw({error, {no_such_transition, [
+        {modron_id, ID},
+        {modron_state, Name},
+        {modron_entry_actions, OnEntry},
+        {modron_exit_actions, OnExit},
+        {modron_transition_to, Event}
+      ]}})
   end.
 
 enter_state(#state{on_entry=OnEntry}) -> OnEntry.


### PR DESCRIPTION
This should vastly improve debuggabilty since we now can see which transition broke.

