### PR TITLE
chore: avoids log line-wrapping and deal with utf8 binaries

### DIFF
--- a/src/mechanus_modron.erl
+++ b/src/mechanus_modron.erl
@@ -274,7 +274,7 @@ effect(#modron{id=ID, actions=As, act_hist=Hist} = M) ->
     fun(A, #modron{data=D, events=Es} = M) ->
       case ?lift(A:perform(D)) of
         {ok, R} ->
-          ?info("~p: action ~p succeeded: ~p", [ID, A, R]),
+          ?info("~p: action ~p succeeded: ~9999tp", [ID, A, R]),
           %% Inject before existing events!
           M#modron{data=merge(D, R#result.output), events=R#result.events++Es};
         {error, Rsn} = Err ->


### PR DESCRIPTION
Making ~p into ~9999tp so that the mrl state is printed on a single line (well, up to column 9999) and t so it can print utf8 binaries.