### PR TITLE
chore: Better result logging

### DIFF
--- a/src/mechanus.erl
+++ b/src/mechanus.erl
@@ -28,6 +28,7 @@
 -export([result/0]).
 -export([result/1]).
 -export([result/2]).
+-export([result_to_map/1]).
 
 %% Time
 -export([in/1]).
@@ -96,6 +97,11 @@ result(Output, Events) when is_list(Events) ->
                         is_record(E, event) -> E
                      end || E <- Events]
          }.
+
+result_to_map(#result{output = O, events = E}) ->
+  #{output => O, events => E};
+result_to_map(R) ->
+  R.
 
 data(Data) when is_map(Data) ->
   Data;

--- a/src/mechanus_modron.erl
+++ b/src/mechanus_modron.erl
@@ -282,11 +282,12 @@ effect(#modron{id=ID, actions=As, act_hist=Hist} = M) ->
     fun(A, #modron{data=D, events=Es} = M) ->
       case ?lift(A:perform(D)) of
         {ok, R} ->
-          ?info(#{ description => "Action succeeded"
-                 , action_id => ID
-                 , action_name => A
-                 , result => R
-                 }),
+          %% Set to debug while PII data issue is being addressed
+          ?debug(#{ description => "Action succeeded"
+                  , action_id => ID
+                  , action_name => A
+                  , result => mechanus:result_to_map(R)
+                  }),
           %% Inject before existing events!
           M#modron{data=merge(D, R#result.output), events=R#result.events++Es};
         {error, Rsn} = Err ->


### PR DESCRIPTION
## Description

`mechanus` results are handled from an internal record type, which does not prints well in the logs