### PR TITLE
feat: add counters log less when executing modrons

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,43 @@
+name: Erlang CI
+
+on: [push]
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-22.04
+    name: OTP ${{matrix.otp}}
+    strategy:
+      matrix:
+        otp: ["25", "26", "27"]
+        rebar3: ["3.23.0"]
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - uses: erlef/setup-beam@v1.16.0
+      with:
+        otp-version: ${{matrix.otp}}
+        rebar3-version: ${{matrix.rebar3}}
+    - name: Compile
+      run: make compile
+    - name: Run dialyzer
+      run: make dialyze
+    - name: Run eunit tests
+      run: make eunit
+
+  release:
+    if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'no-release:') == false
+    needs: build_and_test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Bump version and push tag
+      id: tag_version
+      uses: mathieudutour/github-tag-action@v5.3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create a GitHub release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.tag_version.outputs.new_tag }}
+        release_name: Release ${{ steps.tag_version.outputs.new_tag }}
+        body: ${{ steps.tag_version.outputs.changelog }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ deps/
 *.plt
 src/mechanus_lexer.erl
 src/mechanus_parser.erl
+_build/

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,16 @@
-PROJECT = mechanus_fsm
+all: compile
 
-# Options ##############################################################
-EUNIT_OPTS = [verbose]
-ERLC_OPTS = +debug_info +nowarn_shadow_vars +warnings_as_errors \
-            -DS2_USE_LAGER
+compile:
+	rebar3 compile
 
-# Dependecies ##########################################################
-DEPS = stdlib2 eon lager
+clean:
+	rebar3 clean
 
-dep_lager   = git git://github.com/kivra/lager       master
-dep_stdlib2 = git git://github.com/kivra/stdlib2.git master
-dep_eon     = git git://github.com/kivra/eon.git     master
+eunit:
+	rebar3 eunit
 
-# Standard targets #####################################################
-include erlang.mk
+dialyze:
+	rebar3 dialyzer
 
-# Utilities ############################################################
-.PHONY: repl eunit_repl
-
-repl: app
-	@exec erl -pa $(PWD)/ebin -pa $(PWD)/deps/**/ebin \
-            -pa $(PWD)/deps/**/deps/**/ebin
-
-eunit_repl:
-	erl -pa .eunit deps/*/ebin
-
-# eof
+xref:
+	rebar3 xref

--- a/include/mechanus.hrl
+++ b/include/mechanus.hrl
@@ -37,7 +37,7 @@
         , events=[]                   :: [#event{}]    %unprocessed events
         , ev_hist=[]                  :: [#event{}]    %processed events (rev)
         , actions=[]                  :: [module()]    %unprocessed actions
-        , act_hist=[]                 :: [module()]    %processed actions (rev)
+        , act_hist=[]                 :: [[module()]]    %processed actions (rev)
         , spec=error('modron.spec')   :: _             %FSM specification
         }).
 
@@ -49,7 +49,7 @@
 
 -type obj(A, B)  :: eon:object(A, B).
 -type mid()      :: mechanus:id().
--type tid()      :: mechanus_queue:id().
+-type tid()      :: any(). % mechanus_queue:id().
 -type filename() :: string() | atom().
 
 %%%_* Footer ===========================================================

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
            , {d, 'S2_USE_OTP_LOGGER'}
            ]}.
 
-{deps, [ {stdlib2, ".*", {git,"https://github.com/kivra/stdlib2.git", {tag, "v1.4.3"}}}
+{deps, [ {stdlib2, ".*", {git,"https://github.com/kivra/stdlib2.git", {branch, "master"}}}
        , {eon,     ".*", {git,"https://github.com/kivra/eon.git",     {branch, "master"}}}
        , {lager,   ".*", {git,"https://github.com/kivra/lager",       {branch, "master"}}}
        , {prometheus, "4.10.0"}

--- a/rebar.config
+++ b/rebar.config
@@ -7,4 +7,5 @@
 {deps, [ {stdlib2, ".*", {git,"https://github.com/kivra/stdlib2.git", {tag, "v1.4.3"}}}
        , {eon,     ".*", {git,"https://github.com/kivra/eon.git",     {branch, "master"}}}
        , {lager,   ".*", {git,"https://github.com/kivra/lager",       {branch, "master"}}}
+       , {prometheus, "4.10.0"}
        ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,27 @@
+{"1.2.0",
+[{<<"eon">>,
+  {git,"https://github.com/kivra/eon.git",
+       {ref,"10a8b462be6dffe8ae164a665a84ae70f73fae9c"}},
+  0},
+ {<<"goldrush">>,
+  {git,"https://github.com/DeadZen/goldrush.git",
+       {ref,"8f1b715d36b650ec1e1f5612c00e28af6ab0de82"}},
+  1},
+ {<<"lager">>,
+  {git,"https://github.com/kivra/lager",
+       {ref,"92b1548f7f97a7fef257dffc45ef7b14006334e6"}},
+  0},
+ {<<"prometheus">>,{pkg,<<"prometheus">>,<<"4.10.0">>},0},
+ {<<"quantile_estimator">>,{pkg,<<"quantile_estimator">>,<<"0.2.1">>},1},
+ {<<"stdlib2">>,
+  {git,"https://github.com/kivra/stdlib2.git",
+       {ref,"86c3a1858481bf23b8c4fdd46691c1f0002c9540"}},
+  0}]}.
+[
+{pkg_hash,[
+ {<<"prometheus">>, <<"792ADBF0130FF61B5FA8826F013772AF24B6E57B984445C8D602C8A0355704A1">>},
+ {<<"quantile_estimator">>, <<"EF50A361F11B5F26B5F16D0696E46A9E4661756492C981F7B2229EF42FF1CD15">>}]},
+{pkg_hash_ext,[
+ {<<"prometheus">>, <<"2A99BB6DCE85E238C7236FDE6B0064F9834DC420DDBD962AAC4EA2A3C3D59384">>},
+ {<<"quantile_estimator">>, <<"282A8A323CA2A845C9E6F787D166348F776C1D4A41EDE63046D72D422E3DA946">>}]}
+].

--- a/rebar.lock
+++ b/rebar.lock
@@ -15,7 +15,7 @@
  {<<"quantile_estimator">>,{pkg,<<"quantile_estimator">>,<<"0.2.1">>},1},
  {<<"stdlib2">>,
   {git,"https://github.com/kivra/stdlib2.git",
-       {ref,"86c3a1858481bf23b8c4fdd46691c1f0002c9540"}},
+       {ref,"f5fdd13de0f02d7b1f9482133a7e4bf8cce14974"}},
   0}]}.
 [
 {pkg_hash,[

--- a/src/mechanus.erl
+++ b/src/mechanus.erl
@@ -22,6 +22,7 @@
 
 %%%_* Exports ==========================================================
 %% Constructors
+-export([init_counters/0]).
 -export([event/1]).
 -export([event/2]).
 -export([event/3]).
@@ -29,6 +30,7 @@
 -export([result/1]).
 -export([result/2]).
 -export([result_to_map/1]).
+
 
 %% Time
 -export([in/1]).
@@ -38,6 +40,7 @@
 -export([minutes/1]).
 -export([hours/1]).
 -export([days/1]).
+-export([is_counters_initialized/0]).
 
 -export_type([data/0]).
 -export_type([event/0]).
@@ -66,6 +69,28 @@
 %% ADTs
 -opaque event()  :: #event{}.
 -opaque result() :: #result{}.
+
+init_counters() ->
+  application:ensure_started(prometheus),
+  prometheus_counter:declare([
+    {name, mechanus_actions},
+    {labels, [action, outcome]},
+    {help, "Number of times a specific action was performed"}
+  ]),
+  prometheus_counter:declare([
+    {name, mechanus_state_transitions},
+    {labels, [old_state, new_state, event]},
+    {help, "Number of times a state transition occured"}
+  ]),
+  prometheus_counter:declare([
+    {name, mechanus_state_transitions_failed},
+    {labels, [old_state, event]},
+    {help, "Number of times a state transition failed to happen"}
+  ]),
+  application:set_env(mechanus_fsm, counters_initialized, true).
+
+is_counters_initialized() ->
+  application:get_env(mechanus_fsm, counters_initialized, false).
 
 %%%_ * Constructors ----------------------------------------------------
 -spec event(atom()) -> event().

--- a/src/mechanus_dsl.erl
+++ b/src/mechanus_dsl.erl
@@ -28,7 +28,7 @@
 -include("mechanus.hrl").
 
 %%%_* Code =============================================================
--spec parse(filename()) -> maybe([_], _).
+-spec parse(filename()) -> 'maybe'([_], _).
 parse(File) when is_atom(File) ->
     parse(?a2l(File) ++ ".mrl");
 parse(File) when ?is_string(File) ->

--- a/src/mechanus_fsm.app.src
+++ b/src/mechanus_fsm.app.src
@@ -20,6 +20,6 @@
  , {vsn,          "0.1.0"}
  , {modules,      []}
  , {registered,   []}
- , {applications, [kernel, stdlib]}
+ , {applications, [kernel, stdlib, prometheus, eon, stdlib2]}
  , {env,          []}
  ]}.

--- a/src/mechanus_modron.erl
+++ b/src/mechanus_modron.erl
@@ -31,7 +31,7 @@
 
 %%%_* Code =============================================================
 %%%_ * API -------------------------------------------------------------
--spec eval(filename() | mechanus:spec(), mechanus:id()) -> maybe(#modron{}, _).
+-spec eval(filename() | mechanus:spec(), mechanus:id()) -> 'maybe'(#modron{}, _).
 %% @doc Construct modron ID according to Spec.
 eval(Source, Mid) ->
   eval(Source, Mid, []).
@@ -55,9 +55,9 @@ data(Data) ->
   eon:new(Data).
 
 -spec apply(#modron{}, #event{} | [#event{}]) ->
-               maybe({done, #modron{}} |
-                     {next, #modron{}} |
-                     {next, #modron{}, timeout()},  _).
+               'maybe'({done, #modron{}} |
+                       {next, #modron{}} |
+                       {next, #modron{}, timeout()},  _).
 %% @doc Send Events to Modron, then take as many steps as possible.
 apply(Modron, Events) ->
   s2_maybe:do(

--- a/src/mechanus_modron.erl
+++ b/src/mechanus_modron.erl
@@ -251,7 +251,8 @@ is_valid(#event{valid_from=TS}) -> mechanus:now() > TS.
 exit_state(#state{name=Name, tab=Tab, on_entry=OnEntry, on_exit=OnExit}, Event, ID) ->
   case eon:get(Tab, Event) of
     {ok, State} ->
-      ?info(#{ description => "State transition applied"
+      update_counter(mechanus_state_transitions, [Name, State#state.name, Event]),
+      ?debug(#{ description => "State transition applied"
              , action_id => ID
              , action_name => Name
              , state => State#state.name
@@ -259,6 +260,7 @@ exit_state(#state{name=Name, tab=Tab, on_entry=OnEntry, on_exit=OnExit}, Event, 
              }),
       {State, OnExit};
     {error, notfound} ->
+      update_counter(mechanus_state_transitions_failed, [Name, Event]),
       ?error(#{ description => "no transition found for action"
               , action_id => ID
               , action_name => Name
@@ -282,13 +284,15 @@ effect(#modron{id=ID, actions=As, act_hist=Hist} = M) ->
     fun(A, #modron{data=D, events=Es} = M) ->
       case ?lift(A:perform(D)) of
         {ok, R} ->
-          ?info(#{ description => "Action succeeded"
+          update_counter(mechanus_actions, [A, success]),
+          ?debug(#{ description => "Action succeeded"
                   , action_id => ID
                   , action_name => A
                   }),
           %% Inject before existing events!
           M#modron{data=merge(D, R#result.output), events=R#result.events++Es};
         {error, Rsn} = Err ->
+          update_counter(mechanus_actions, [A, failure]),
           ?error(#{description => "Action failed"
                  , action_id => ID
                  , action_name => A
@@ -297,6 +301,15 @@ effect(#modron{id=ID, actions=As, act_hist=Hist} = M) ->
           throw(Err)
       end
     end, M#modron{actions=[], act_hist=[As|Hist]}, As).
+
+update_counter(Name, Args) ->
+  case mechanus:is_counters_initialized() of
+    true ->
+      prometheus_counter:inc(Name, Args),
+      ok;
+    false ->
+      ok
+  end.
 
 -spec merge(mechanus:data(), mechanus:data()) -> mechanus:data().
 %% @doc Merge Data2 into Data1, with entries in Data2 taking precedence.
@@ -363,6 +376,7 @@ parse_test() ->
   lookup_email = State#state.name.
 
 eval_apply_test() ->
+  mechanus:init_counters(),
   {ok, M0}        = eval(test_fsm(), s2_time:stamp()),
   {ok, {done, M}} = apply(M0, []),
   done_ok         = (M#modron.state)#state.name.
@@ -382,6 +396,7 @@ parse_rows_test() ->
 
 special_case_test() ->
   %% Delayed event
+  mechanus:init_counters(),
   T0 = mechanus:now(),
   T1 = T0 + 500,
   {ok, M0} = eval(test_fsm2(), T0, [{foo, bar}]),
@@ -394,6 +409,8 @@ special_case_test() ->
   {error, {lifted_exn, _, _}} = apply(M, #event{name=ev2}),
 
   ok.
+
+
 
 merge_test() ->
   Obj     = merge([foo, 1], [foo, 2]),


### PR DESCRIPTION
This change adds the ability to update counters when actions are executed and transitions are taken. The change also decreases the log level when a successful action has been taken or transition has been made to debug from info to decrease the log load on cybertron.